### PR TITLE
 Ollama4j dependency 1.0.79 

### DIFF
--- a/AppWish/AppWish/dependency-reduced-pom.xml
+++ b/AppWish/AppWish/dependency-reduced-pom.xml
@@ -4,8 +4,8 @@
   <groupId>pn.dev</groupId>
   <artifactId>code-generator-gui-ollama</artifactId>
   <name>CodeGenerator-GUI</name>
-  <version>2.0.3</version>
-  <description>The GUI interface for the pn.dev.code-generator-ollama library is included in this package</description>
+  <version>2.0.4</version>
+  <description>The GUI interface for the pn.dev.code-generator-ollama library</description>
   <inceptionYear>2024</inceptionYear>
   <developers>
     <developer>
@@ -14,7 +14,8 @@
       <email>snow_900@outlook.com</email>
       <roles>
         <role>Security Champion</role>
-        <role>Backend Engineer</role>
+        <role>CCT Scheme Committee (2023-2026)</role>
+        <role>Open Source Developer</role>
       </roles>
       <timezone>Central European Time</timezone>
     </developer>

--- a/AppWish/AppWish/pom.xml
+++ b/AppWish/AppWish/pom.xml
@@ -5,11 +5,11 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>pn.dev</groupId>
     <artifactId>code-generator-gui-ollama</artifactId>
-    <version>2.0.3</version>
+    <version>2.0.4</version>
     <name>CodeGenerator-GUI</name>
 
 
-    <description>The GUI interface for the pn.dev.code-generator-ollama library is included in this package</description>
+    <description>The GUI interface for the pn.dev.code-generator-ollama library</description>
     <inceptionYear>2024</inceptionYear>
 
     <developers>
@@ -19,11 +19,19 @@
             <email>snow_900@outlook.com</email>
             <roles>
                 <role>Security Champion</role>
-                <role>Backend Engineer</role>
+                <role>CCT Scheme Committee (2023-2026)</role>
+                <role>Open Source Developer</role>
             </roles>
             <timezone>Central European Time</timezone>
         </developer>
     </developers>
+
+    <licenses>
+    <license>
+        <name>MIT License</name>
+        <url>https://raw.githubusercontent.com/pwgit-create/APPWISH_OLLAMA/master/LICENSE</url>
+    </license>
+</licenses>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -45,7 +53,7 @@
         <dependency>
             <groupId>pn.dev</groupId>
             <artifactId>code-generator-ollama</artifactId>
-            <version>2.0.3</version>
+            <version>2.0.4</version>
         </dependency>
         <dependency>
             <groupId>org.openjfx</groupId>

--- a/cg/CodeGenerator/CodeGenerator/dependency-reduced-pom.xml
+++ b/cg/CodeGenerator/CodeGenerator/dependency-reduced-pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>pn.dev</groupId>
   <artifactId>code-generator-ollama</artifactId>
-  <version>2.0.3</version>
+  <version>2.0.4</version>
   <description>The Java Application-Generator (pn.dev.code-generator-ollama) creates applications by giving a string of your desired features for a Java application, like this: AppSystem.StartCodeGenerator(String appWish)</description>
   <inceptionYear>2024</inceptionYear>
   <developers>
@@ -12,8 +12,8 @@
       <name>Peter Westin</name>
       <email>snow_900@outlook.com</email>
       <roles>
-        <role>Security Champion</role>
-        <role>Backend Engineer</role>
+        <role>CCT Scheme Committee (2023-2026)</role>
+        <role>Open Source Developer</role>
       </roles>
       <timezone>Central European Time</timezone>
     </developer>

--- a/cg/CodeGenerator/CodeGenerator/pom.xml
+++ b/cg/CodeGenerator/CodeGenerator/pom.xml
@@ -46,12 +46,12 @@
    <dependencies>
 
     <!-- https://mvnrepository.com/artifact/io.github.amithkoujalgi/ollama4j -->
-<dependency>
-    <groupId>io.github.amithkoujalgi</groupId>
-    <artifactId>ollama4j</artifactId>
-    <version>1.0.73</version>
-</dependency>
-        <!-- https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter-api -->
+       <dependency>
+           <groupId>io.github.ollama4j</groupId>
+           <artifactId>ollama4j</artifactId>
+           <version>1.0.79</version>
+       </dependency>
+       <!-- https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter-api -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>

--- a/cg/CodeGenerator/CodeGenerator/pom.xml
+++ b/cg/CodeGenerator/CodeGenerator/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>pn.dev</groupId>
     <artifactId>code-generator-ollama</artifactId>
-    <version>2.0.3</version>
+    <version>2.0.4</version>
 
 
     <description>The Java Application-Generator (pn.dev.code-generator-ollama) creates applications by giving a string of your desired features for a Java application, like this: AppSystem.StartCodeGenerator(String appWish)</description>
@@ -18,12 +18,19 @@
             <id>Peter</id>
             <email>snow_900@outlook.com</email>
             <roles>
-                <role>Security Champion</role>
-                <role>Backend Engineer</role>
+                <role>CCT Scheme Committee (2023-2026)</role>
+                <role>Open Source Developer</role>
             </roles>
             <timezone>Central European Time</timezone>
         </developer>
     </developers>
+
+    <licenses>
+        <license>
+            <name>MIT License</name>
+            <url>https://raw.githubusercontent.com/pwgit-create/APPWISH_OLLAMA/master/LICENSE</url>
+        </license>
+    </licenses>
 
 
     <properties>

--- a/cg/CodeGenerator/CodeGenerator/src/main/java/pn/cg/ollama_ai_remote/request/RequestHandlerImpl.java
+++ b/cg/CodeGenerator/CodeGenerator/src/main/java/pn/cg/ollama_ai_remote/request/RequestHandlerImpl.java
@@ -1,6 +1,13 @@
 package pn.cg.ollama_ai_remote.request;
 
 
+import io.github.ollama4j.OllamaAPI;
+import io.github.ollama4j.exceptions.OllamaBaseException;
+
+import io.github.ollama4j.models.OllamaResult;
+import io.github.ollama4j.utils.Options;
+import io.github.ollama4j.utils.OptionsBuilder;
+import io.github.ollama4j.utils.PromptBuilder;
 import pn.cg.app_system.code_generation.model.SuperApp;
 import pn.cg.datastorage.CodeGeneratorConfig;
 import pn.cg.datastorage.DataStorage;
@@ -9,12 +16,7 @@ import pn.cg.datastorage.constant.QuestionConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.github.amithkoujalgi.ollama4j.core.OllamaAPI;
-import io.github.amithkoujalgi.ollama4j.core.exceptions.OllamaBaseException;
-import io.github.amithkoujalgi.ollama4j.core.models.OllamaResult;
-import io.github.amithkoujalgi.ollama4j.core.utils.Options;
-import io.github.amithkoujalgi.ollama4j.core.utils.OptionsBuilder;
-import io.github.amithkoujalgi.ollama4j.core.utils.PromptBuilder;
+
 import pn.cg.util.CodeGeneratorUtil;
 import pn.cg.util.StringUtil;
 
@@ -116,7 +118,7 @@ public class RequestHandlerImpl implements RequestHandler {
 
         OllamaResult result = null;
         try {
-            result = api.generate(codeGeneratorConfig.getOllamaModel(), promptBuilder.build(), options);
+            result = api.generate(codeGeneratorConfig.getOllamaModel(), promptBuilder.build(),false, options);
 
         } catch (OllamaBaseException | IOException | InterruptedException e) {
             log.error("Error while sending a request to the local Ollama Server");
@@ -262,7 +264,7 @@ public class RequestHandlerImpl implements RequestHandler {
 
         OllamaResult result = null;
         try {
-            result = api.generate(codeGeneratorConfig.getOllamaModel(), promptBuilder.build(), options);
+            result = api.generate(codeGeneratorConfig.getOllamaModel(), promptBuilder.build(),false ,options);
 
         } catch (OllamaBaseException | IOException | InterruptedException e) {
             log.error("Error while sending a request to the local Ollama Server");
@@ -287,7 +289,7 @@ public class RequestHandlerImpl implements RequestHandler {
 
         OllamaResult result = null;
         try {
-            result = api.generate(codeGeneratorConfig.getOllamaModel(), initialPrompt.build(), options);
+            result = api.generate(codeGeneratorConfig.getOllamaModel(), initialPrompt.build(),false, options);
 
 
         } catch (OllamaBaseException | IOException | InterruptedException e) {


### PR DESCRIPTION
1. The Ollama4j dependency version in AppWish has been changed to 1.0.79.  This version offers more customization options for the request to Ollama API, including the ability to disable the template format for the query and various optimizations.

1.1. The migration steps (1.0.73 to 1.0.79) have been put in place.