### PR TITLE
Fixed so the codebase generations with codegeex4 ai model will work b…

### DIFF
--- a/cg/CodeGenerator/CodeGenerator/src/main/java/pn/cg/util/StringUtil.java
+++ b/cg/CodeGenerator/CodeGenerator/src/main/java/pn/cg/util/StringUtil.java
@@ -5,9 +5,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import pn.cg.datastorage.constant.CommonStringConstants;
 
-import java.util.Arrays;
-import java.util.LinkedList;
-import java.util.List;
+import java.util.*;
 
 import static pn.cg.util.CodeGeneratorUtil.ValidateResponseOnSuperAppGetAllClassesQuestion;
 
@@ -262,6 +260,7 @@ public class StringUtil {
      * @return List<String>
      */
     public static List<String> GetListOfClassNamesInSuperAppGeneration(String input) {
+        final String MAIN_CLASS_NAME = "Main";
         try {
             String[] classNamesArr = input.split("\n");
             List<String> tmpClassNames = new LinkedList<>();
@@ -288,7 +287,15 @@ public class StringUtil {
                 }
             }
 
-            return tmpClassNames.stream().filter(line -> !(line.contains(" "))).toList();
+            tmpClassNames =  tmpClassNames.stream().filter(line -> !(line.contains(" "))).toList();
+
+            if(!tmpClassNames.isEmpty() && tmpClassNames.get(0).equalsIgnoreCase(MAIN_CLASS_NAME)){
+                List<String> mutableList = new ArrayList<>(tmpClassNames);
+                Collections.reverse(mutableList);
+                return mutableList;
+            }
+
+            return tmpClassNames;
 
         } catch (Exception e) {
 

--- a/cg/CodeGenerator/CodeGenerator/src/test/java/pn/cg/util/StringUtilTest.java
+++ b/cg/CodeGenerator/CodeGenerator/src/test/java/pn/cg/util/StringUtilTest.java
@@ -353,4 +353,17 @@ public class StringUtilTest {
         Assertions.assertEquals(EXPECTED, ACTUAL);
     }
 
+    @Test
+    public void ReverseListOfClassNamesInSuperAppGenerationIfFirstClassIsNamedMain() {
+
+        final String TEST_INPUT = "1. Main\n2. PackageScanner";
+        final String PERFECT_RESPONSE_FROM_AI_MODEL = "PackageScanner\nMain";
+
+
+        final List<String> EXPECTED = Arrays.stream(PERFECT_RESPONSE_FROM_AI_MODEL.split("\n")).toList();
+        final List<String> ACTUAL = StringUtil.GetListOfClassNamesInSuperAppGeneration(TEST_INPUT);
+
+        Assertions.assertEquals(EXPECTED, ACTUAL);
+    }
+
 }


### PR DESCRIPTION
![addToPr](https://github.com/user-attachments/assets/72318bfd-6666-47ba-b485-ef161c13d6e7)

The [codegeex4](https://ollama.com/library/codegeex4) model may deliver the class order incorrectly during code base generation. In the event that happens, the list of classes will be reversed.   I suggest sticking to CodeStral for code base generation because CodeGen4 is more effective at single apps and continuations (running fast and smoothly on them). Having a fix for the order in place is a good idea since they may update that model. 

Code base generation with good results (at this point in time) is achieved by using these Codestral models with these settings as a minimum.

NUM_CTX =10240
Other Values can be default

[Codestral q5](https://ollama.com/library/codestral:22b-v0.1-q5_0)
[Codestral q8](https://ollama.com/library/codestral:22b-v0.1-q8_0)