### PR TITLE
Develop

### DIFF
--- a/AppWish/AppWish/pom.xml
+++ b/AppWish/AppWish/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>pn.dev</groupId>
     <artifactId>code-generator-gui-ollama</artifactId>
-    <version>2.1</version>
+    <version>2.1.1</version>
     <name>CodeGenerator-GUI</name>
 
 
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>pn.dev</groupId>
             <artifactId>code-generator-ollama</artifactId>
-            <version>2.1</version>
+            <version>2.1.1</version>
         </dependency>
         <dependency>
             <groupId>org.openjfx</groupId>

--- a/AppWish/AppWish/src/main/java/pn/app_wish/constant/AboutConstants.java
+++ b/AppWish/AppWish/src/main/java/pn/app_wish/constant/AboutConstants.java
@@ -3,7 +3,7 @@ package pn.app_wish.constant;
 
 public record AboutConstants() {
 
-    private static final String APP_WISH_VERSION = "Appwish Enterprise 2.1";
+    private static final String APP_WISH_VERSION = "Appwish Enterprise 2.1.1";
     private static final String ABOUT_APP_WISH = "AppWish 2 is a open source project that creates Java applications from text input with the help of AI models";
     private static final String DEVELOPED_BY = "Pwgit-Create / Peter Westin";
     private static final String CONTACT = "\nEmail: snow_900@outlook.com";

--- a/cg/CodeGenerator/CodeGenerator/pom.xml
+++ b/cg/CodeGenerator/CodeGenerator/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>pn.dev</groupId>
     <artifactId>code-generator-ollama</artifactId>
-    <version>2.1</version>
+    <version>2.1.1</version>
 
 
     <description>The Java Application-Generator (pn.dev.code-generator-ollama) creates applications by giving a string of your desired features for a Java application, like this: AppSystem.StartCodeGenerator(String appWish)</description>

--- a/cg/CodeGenerator/CodeGenerator/src/main/java/pn/cg/ollama_ai_remote/request/RequestHandlerImpl.java
+++ b/cg/CodeGenerator/CodeGenerator/src/main/java/pn/cg/ollama_ai_remote/request/RequestHandlerImpl.java
@@ -103,7 +103,7 @@ public class RequestHandlerImpl implements RequestHandler {
                     .addLine(question)
                     .addLine(QuestionConstants.NOTE_TO_KEEP_AS_MUCH_ORIGINAL_STRUCTURE_AS_POSSIBLE)
                     .addLine(QuestionConstants.NO_EXISTING_CODE_COMMENTS)
-                    .add(QuestionConstants.NEVER_ADD_EXISTING_CODE_REFERENCE_COMMENTS)
+                    .addLine(QuestionConstants.NEVER_ADD_EXISTING_CODE_REFERENCE_COMMENTS)
                     .addLine(QuestionConstants.AND_CORRECT_IMPORTS)
                     .addLine(QuestionConstants.MARK_START_CHAR_DELIMITER)
                     .addLine(QuestionConstants.MARK_THE_END_CHAR_DELIMITER)


### PR DESCRIPTION
Corrected a new line error in the prompt that only happened if you continued to build on an application. That process should be accelerated by this fix. The prompt becomes large because Java code from a file is provided as partial input. It's therefore paramount that the non-java code part is free of errors.